### PR TITLE
prevent "where is my code" text views from truncating text

### DIFF
--- a/CovidWatch/Views/Reporting/WhereIsMyCode.swift
+++ b/CovidWatch/Views/Reporting/WhereIsMyCode.swift
@@ -39,6 +39,7 @@ struct WhereIsMyCode: View {
 
                                 Text(verbatim: nextStep.description)
                                     .foregroundColor(Color("Text Color"))
+                                    .fixedSize(horizontal: false, vertical: true)
                                     .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
                                     .font(.custom("Montserrat-Regular", size: 14))
 


### PR DESCRIPTION
prevent "where is my code" text views from truncating text

via a .fixedSize()

https://app.asana.com/0/1188301658055194/1188419700860817/f